### PR TITLE
Adding interval/requestAnimationFrame

### DIFF
--- a/lib/bouncer.html
+++ b/lib/bouncer.html
@@ -4,6 +4,7 @@
     <title>bouncer</title>
     <link rel="stylesheet" type="text/css" href="bouncer.css">
     <script src="../node_modules/rx/dist/rx.all.js"></script>
+    <script src="rx.dom.lite.js"></script>
   </head>
 
   <body>
@@ -23,4 +24,3 @@
     <script src="bouncer.js"></script>
   </body>
 </html>
-

--- a/lib/bouncer.js
+++ b/lib/bouncer.js
@@ -27,25 +27,25 @@ yChange
     data.ball.yVel = data.vel;
   });
 
-Rx.Observable.fromEvent(count, 'change').subscribe(function(data) {
+Rx.events.change(count).subscribe(function(data) {
   clearBalls();
   ballCount = parseInt(data.target.value);
   renderBalls();
 });
 
-Rx.Observable.fromEvent(slower, 'click').subscribe(function(data) {
+Rx.events.click(slower).subscribe(function(data) {
   clearBalls();
   maxSpeed = maxSpeed/2;
   renderBalls();
 });
 
-Rx.Observable.fromEvent(faster, 'click').subscribe(function(data) {
+Rx.events.click(faster).subscribe(function(data) {
   clearBalls();
   maxSpeed = maxSpeed + 0.5;
   renderBalls();
 });
 
-Rx.Observable.fromEvent(liner, 'click').subscribe(function(data) {
+Rx.events.click(liner).subscribe(function(data) {
   var bound = 400, length = 50;
   var x1 = Math.random()*bound;
   var y1 = Math.random()*bound;
@@ -60,7 +60,7 @@ Rx.Observable.fromEvent(liner, 'click').subscribe(function(data) {
   line(x1, y1, x2, y2, 2);
 });
 
-Rx.Observable.fromEvent(sizer, 'change').subscribe(function(data) {
+Rx.events.change(sizer).subscribe(function(data) {
   clearBalls();
   ballSize = parseInt(data.target.value);
   setupProbes();
@@ -175,17 +175,19 @@ function checkCollisions() {
   }
 }
 
+function moveAll(recurse) {
+  for (var i = 1; i <= ballCount; i++) {
+    balls[i].move();
+  }
+  recurse();
+}
+
 function init() {
   renderBalls();
   setupProbes();
-  prober = setInterval(checkCollisions, probeInterval);
+  prober = Rx.Observable.interval(probeInterval).subscribe(checkCollisions);
 
-  (function moveAll() {
-    for (var i = 1; i <= ballCount; i++) {
-      balls[i].move();
-    }
-    requestAnimationFrame(moveAll);
-  })();
+  Rx.Scheduler.requestAnimationFrame.scheduleRecursive(moveAll);
 }
 
 function setupProbes() {

--- a/lib/rx.dom.lite.js
+++ b/lib/rx.dom.lite.js
@@ -1,0 +1,73 @@
+(function (root, Rx) {
+  Rx.events = {};
+  ['change', 'click'].forEach(function (event) {
+    Rx.events[event] = function (element, selector) {
+      return Rx.Observable.fromEvent(element, event, selector);
+    };
+  });
+
+  // Get the right animation frame method
+  var requestAnimFrame, cancelAnimFrame;
+  if (root.requestAnimationFrame) {
+    requestAnimFrame = root.requestAnimationFrame;
+    cancelAnimFrame = root.cancelAnimationFrame;
+  } else if (root.mozRequestAnimationFrame) {
+    requestAnimFrame = root.mozRequestAnimationFrame;
+    cancelAnimFrame = root.mozCancelAnimationFrame;
+  } else if (root.webkitRequestAnimationFrame) {
+    requestAnimFrame = root.webkitRequestAnimationFrame;
+    cancelAnimFrame = root.webkitCancelAnimationFrame;
+  } else if (root.msRequestAnimationFrame) {
+    requestAnimFrame = root.msRequestAnimationFrame;
+    cancelAnimFrame = root.msCancelAnimationFrame;
+  } else if (root.oRequestAnimationFrame) {
+    requestAnimFrame = root.oRequestAnimationFrame;
+    cancelAnimFrame = root.oCancelAnimationFrame;
+  } else {
+    requestAnimFrame = function(cb) { root.setTimeout(cb, 1000 / 60); };
+    cancelAnimFrame = root.clearTimeout;
+  }
+
+  /**
+  * Gets a scheduler that schedules schedules work on the requestAnimationFrame for immediate actions.
+  */
+  Rx.Scheduler.requestAnimationFrame = (function () {
+
+    function scheduleNow(state, action) {
+      var scheduler = this,
+      disposable = new Rx.SingleAssignmentDisposable();
+      var id = requestAnimFrame(function () {
+        !disposable.isDisposed && (disposable.setDisposable(action(scheduler, state)));
+      });
+      return new Rx.CompositeDisposable(disposable, Rx.Disposable.create(function () {
+        cancelAnimFrame(id);
+      }));
+    }
+
+    function scheduleRelative(state, dueTime, action) {
+      var scheduler = this,
+          dt = Rx.Scheduler.normalize(dueTime);
+      if (dt === 0) { return scheduler.scheduleWithState(state, action); }
+
+      var disposable = new Rx.SingleAssignmentDisposable();
+
+      var id = root.setTimeout(function () {
+        if (!disposable.isDisposed) {
+          disposable.setDisposable(action(scheduler, state));
+        }
+      }, dt);
+
+      return new Rx.CompositeDisposable(disposable, Rx.Disposable.create(function () {
+        root.clearTimeout(id);
+      }));
+    }
+
+    function scheduleAbsolute(state, dueTime, action) {
+      return this.scheduleWithRelativeAndState(state, dueTime - this.now(), action);
+    }
+
+    return new Rx.Scheduler(Date.now, scheduleNow, scheduleRelative, scheduleAbsolute);
+
+  }());
+
+}(this, this.Rx));


### PR DESCRIPTION
Added the following:
- Shorthand for events using `Rx.events.*` such as `click`, `change`, etc
- Add requestAnimationFrame scheduler so there is no dependency in `bouncer.js` directly on the `requestAnimationFrame`.  Added a recursive call via `scheduleRecursive` to update the balls.
- Added the use of `Rx.Observable.interval` instead of the explicit `setInterval` usage.
